### PR TITLE
Allowing other developers to integrate their scripts with Roam42

### DIFF
--- a/ext/load-extra-features.js
+++ b/ext/load-extra-features.js
@@ -1,0 +1,3 @@
+const extraFeatures = typeof window.extraRoam42Features !== 'undefined' ? window.extraRoam42Features : [];
+
+extraFeatures.forEach((s, i) => addScriptToPage(`extra-roam42-feature-${i}`, s));

--- a/main.js
+++ b/main.js
@@ -1,12 +1,6 @@
 /* global  loadKeyEvents, loadTypeAhead, loadJumpNav, jumpToDateComponent, rmQuickRefenceSystem, device, displayStartup */
 
 const disabledFeatures = typeof window.disabledFeatures !== 'undefined' ? window.disabledFeatures : [];
-const extraRoam42Features = typeof window.extraRoam42Features !== 'undefined' ? window.extraRoam42Features : [];
-const extraFeatures = extraRoam42Features === 'all' ? [
-  "https://roam.davidvargas.me/master/google-calendar.js",
-  "https://roam.davidvargas.me/master/emojis.js"
-  // Developers in the Roam JS ecosystem could add their roam scripts here!
-] : extraRoam42Features;
 
 function addScriptToPage(tagId, script) {
   addElementToPage(Object.assign(document.createElement('script'),{src:script}) , tagId, 'text/javascript')
@@ -62,8 +56,7 @@ addScriptToPage( 'typeAheadData',   URLScriptServer + 'ext/typeaheadData.js'    
 addScriptToPage( 'lookupUI',        URLScriptServer + 'ext/typeaheadUI.js'        )
 addScriptToPage( 'templatePoc',     URLScriptServer + 'ext/templatepoc.js'        )
 addScriptToPage( 'jumpToDate',      URLScriptServer + 'ext/jump-to-date.js'       )
-
-extraFeatures.forEach((s, i) => addScriptToPage(`extra-roam42-feature-${i}`, s));
+addScriptToPage( 'jumpToDate',      URLScriptServer + 'ext/load-extra-features.js')
 
 // Give the libraries a few seconds to get comfy in their new home 
 // and then let the extension dance, that is to say,

--- a/main.js
+++ b/main.js
@@ -56,7 +56,7 @@ addScriptToPage( 'typeAheadData',   URLScriptServer + 'ext/typeaheadData.js'    
 addScriptToPage( 'lookupUI',        URLScriptServer + 'ext/typeaheadUI.js'        )
 addScriptToPage( 'templatePoc',     URLScriptServer + 'ext/templatepoc.js'        )
 addScriptToPage( 'jumpToDate',      URLScriptServer + 'ext/jump-to-date.js'       )
-addScriptToPage( 'jumpToDate',      URLScriptServer + 'ext/load-extra-features.js')
+addScriptToPage( 'loadExtraFeatures', URLScriptServer + 'ext/load-extra-features.js')
 
 // Give the libraries a few seconds to get comfy in their new home 
 // and then let the extension dance, that is to say,

--- a/main.js
+++ b/main.js
@@ -1,6 +1,12 @@
 /* global  loadKeyEvents, loadTypeAhead, loadJumpNav, jumpToDateComponent, rmQuickRefenceSystem, device, displayStartup */
 
-const disabledFeatures = typeof window.disabledFeatures !== 'undefined' ? window.disabledFeatures : []; 
+const disabledFeatures = typeof window.disabledFeatures !== 'undefined' ? window.disabledFeatures : [];
+const extraRoam42Features = typeof window.extraRoam42Features !== 'undefined' ? window.extraRoam42Features : [];
+const extraFeatures = extraRoam42Features === 'all' ? [
+  "https://roam.davidvargas.me/master/google-calendar.js",
+  "https://roam.davidvargas.me/master/emojis.js"
+  // Developers in the Roam JS ecosystem could add their roam scripts here!
+] : extraRoam42Features;
 
 function addScriptToPage(tagId, script) {
   addElementToPage(Object.assign(document.createElement('script'),{src:script}) , tagId, 'text/javascript')
@@ -56,6 +62,8 @@ addScriptToPage( 'typeAheadData',   URLScriptServer + 'ext/typeaheadData.js'    
 addScriptToPage( 'lookupUI',        URLScriptServer + 'ext/typeaheadUI.js'        )
 addScriptToPage( 'templatePoc',     URLScriptServer + 'ext/templatepoc.js'        )
 addScriptToPage( 'jumpToDate',      URLScriptServer + 'ext/jump-to-date.js'       )
+
+extraFeatures.forEach((s, i) => addScriptToPage(`extra-roam42-feature-${i}`, s));
 
 // Give the libraries a few seconds to get comfy in their new home 
 // and then let the extension dance, that is to say,


### PR DESCRIPTION
The strategy here is that other developers should be able to allow their scripts to be integrated with Roam42, but shouldn't be included by default. That could lead to weird dependency issues if not managed properly or iteratively.

For those who want to add extra features from any source, they add the following to their `[[roam/js]]` code block:
```javascript
window.extraRoam42Features = [
    // Add each script here as an array of strings
];
```

For those who are brave enough to just include everything, they could add the following to their `[[roam/js]]` code block:
```javascript
window.extraRoam42Features = "all";
```

Let me know what you think!