### PR TITLE
Supporting Custom Commands in Smart Blocks

### DIFF
--- a/ext/smartBlocks.js
+++ b/ext/smartBlocks.js
@@ -13,6 +13,7 @@
   roam42.smartBlocks.activeWorkflow.focusOnBlock = ''; // if set with <%FOCUSONBLOCK%> Will move to this block for focus mode after workflow
   roam42.smartBlocks.activeWorkflow.arrayToWrite = []; // use to output multiple blocks from a command
   roam42.smartBlocks.exclusionBlockSymbol = '!!!!****!!!!****!!!!****!!!!****!!!!****'; //used to indicate a block is not to be inserted
+  roam42.smartBlocks.customCommands = [];
   
   roam42.smartBlocks.initialize = async ()=>{
     var smartBlockTrigger = ";;";

--- a/ext/smartBlocksCmd.js
+++ b/ext/smartBlocksCmd.js
@@ -50,7 +50,8 @@
       valueArray.push({key: '<% GET %> (SmartBlock function)',                icon:'gear', value: '<%GET:&&&%>',            processor:'static'});
       valueArray.push({key: '<% SET %> (SmartBlock function)',                icon:'gear', value: '<%SET:&&&%>',            processor:'static'});
       valueArray.push({key: '<% CLEARVARS %> (SmartBlock function)',          icon:'gear', value: '<%CLEARVARS%>',          processor:'static'});
-    };  
+      roam42.smartBlocks.customCommands.forEach(v => valueArray.push(v));
+    };
 
     roam42.smartBlocks.proccessBlockWithSmartness = async (textToProcess)=>{
       let ifCommand = null;  // null if no IF, true process THEN, false process ELSE
@@ -191,7 +192,10 @@
         var textToProcess = match.replace('<%SET:','').replace('%>','');
         roam42.smartBlocks.activeWorkflow.vars[textToProcess.substring(0,textToProcess.search(','))] = textToProcess.substring(textToProcess.search(',')+1,);
         return '';   
-      });    
+      });
+      for (const { value, processor } of roam42.smartBlocks.customCommands) {
+        textToProcess = await roam42.common.replaceAsync(textToProcess, new RegExp(value, 'g'), processor); 
+      }
       if(textToProcess.includes(roam42.smartBlocks.exclusionBlockSymbol)) return roam42.smartBlocks.exclusionBlockSymbol; //skip this block
       return textToProcess; //resert new text
     }


### PR DESCRIPTION
Here's one stab at supporting custom commands in Smart Blocks, which will allow other developers to plug in and play their extensions.

Here's the output:
![image](https://user-images.githubusercontent.com/7143571/100007867-b2a05e80-2d9a-11eb-8be8-8196ddc68952.png)

Here's the relevant RoamJS PR: https://github.com/dvargas92495/roam-js-extensions/pull/356

The most important consumer lines of codes are here: https://github.com/dvargas92495/roam-js-extensions/pull/356/files#diff-91334554eb32934f7f0896d0483c0a42f89be062babe44bbcb7a18bf3b288adfR669-R680

Since we can't guarantee which script loads first, I'm "registering" the command when the user starts typing and `window.roam42` is available

I'm also returning the function in `processor`. Figure this is temporary until your `registerCommand` API is available.

Finally, as you see in the image above, all of the events are in the same block. Ideally, smart blocks could return a more flexible data structure from custom commands so that the consumer could split into multiple blocks. For now, I think this is sufficient for POC