### PR TITLE
Not all buttons are in Roam Blocks

### DIFF
--- a/ext/smartBlocks.js
+++ b/ext/smartBlocks.js
@@ -383,6 +383,9 @@
     roam42.smartBlocks.buttonClickHandler = async (target)=>{
       if(target.tagName=='BUTTON') {
         var block = target.closest('.roam-block');
+        if (!block) {
+          return;
+        }
         var blockInfo = (await roam42.common.getBlockInfoByUID(block.id.substring( block.id.length -9)))[0][0].string;
         if(blockInfo.includes( target.textContent + ':42SmartBlock:' )) {
           const regex = new RegExp(`{{((${target.textContent})(:42SmartBlock:)(.*?))}}`);


### PR DESCRIPTION
Was seeing the following null pointer exception after clicking a button in one of my overlays. Because not all buttons are in roam blocks, I think Roam42 should have this guard before preceding.

Error:
![image](https://user-images.githubusercontent.com/7143571/101671470-87687100-3a22-11eb-8e1c-7d071dec7b50.png)

Button:
![image](https://user-images.githubusercontent.com/7143571/101671452-82a3bd00-3a22-11eb-89b4-24caf22bca16.png)
