### PR TITLE
chore(GitHub Action): Unrecognized named-value: 'env' issue

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   deploy:
-    if: github.repository == 'dvargas92495/roam42'
+    if: ${{ github.repository == 'dvargas92495/roam42' }}
     runs-on: ubuntu-latest
     name: Deploy
     steps:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   deploy:
-    if: ${{ env.GITHUB_REPOSITORY == 'dvargas92495/roam42' }}
+    if: github.repository == 'dvargas92495/roam42'
     runs-on: ubuntu-latest
     name: Deploy
     steps:


### PR DESCRIPTION
# Fixes

- fixes issue with GitHub workflow due to invalid syntax ([see example](https://github.com/dvargas92495/roam42/actions/runs/829370295))

The solution is based on suggestions I found [here](https://github.community/t/run-scheduled-workflows-only-from-the-main-repository/17589/2) and [here](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context).