### PR TITLE
Autotag unlink finder fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "workbench",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "workbench",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "dependencies": {
         "@mozilla/readability": "^0.3.0",
         "buffer": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@types/mozilla-readability": "^0.2.0",
     "@types/turndown": "^5.0.1"
   },
-  "version": "1.1.4",
+  "version": "1.1.5",
   "samepage": {
     "extends": "node_modules/roamjs-components/package.json"
   }

--- a/src/features/jumpNav.tsx
+++ b/src/features/jumpNav.tsx
@@ -240,9 +240,11 @@ const expandReferenceChildren = () =>
         })
       );
       const li = Array.from(
-        document.querySelector(".bp3-popover-content > div> ul").children
-      ).find((e: HTMLLinkElement) => e.innerText === "Expand all");
-      (li?.childNodes[0] as HTMLElement).click();
+        document.querySelector(
+          '.bp3-transition-container:not([style*="display: none;"]) .bp3-popover-content > div > ul'
+        )?.children || []
+      ).find((e: Element) => (e as HTMLLinkElement).innerText === "Expand all");
+      (li?.childNodes[0] as HTMLElement)?.click();
     });
 const collapseReferenceChildren = () =>
   document
@@ -254,8 +256,12 @@ const collapseReferenceChildren = () =>
         })
       );
       const li = Array.from(
-        document.querySelector(".bp3-popover-content > div> ul").children
-      ).find((e: HTMLLinkElement) => e.innerText === "Collapse all");
+        document.querySelector(
+          '.bp3-transition-container:not([style*="display: none;"]) .bp3-popover-content > div > ul'
+        )?.children || []
+      ).find(
+        (e: Element) => (e as HTMLLinkElement).innerText === "Collapse all"
+      );
       (li?.childNodes[0] as HTMLElement).click();
     });
 const copyBlockRef = () => {


### PR DESCRIPTION
`Unlink Finder` creates a hidden context menu
https://github.com/dvargas92495/autotag/blob/86093b30262659560c94375d65918ace566c8952/src/unlink-finder.ts#L621

The WorkBench `Expand/Collapse Reference Children` command was selecting that instead of the ones it created.

Relevant Slack: https://roamresearch.slack.com/archives/C04H4739402/p1687718094089049