### PR TITLE
1.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "workbench",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "workbench",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "dependencies": {
         "@mozilla/readability": "^0.3.0",
         "buffer": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@types/mozilla-readability": "^0.2.0",
     "@types/turndown": "^5.0.1"
   },
-  "version": "1.2.3",
+  "version": "1.2.4",
   "samepage": {
     "extends": "node_modules/roamjs-components/package.json"
   }


### PR DESCRIPTION
Latest Roam Depot merge was only up to 1.1.5, I believe: https://github.com/Roam-Research/roam-depot/pull/702

Creating this to see if we can get it up to date, or see what's going on.