### PR TITLE
refreshAttributeSelect API

### DIFF
--- a/docs/attribute-select.md
+++ b/docs/attribute-select.md
@@ -49,6 +49,12 @@ You can customize the appearance of the dropdowns by targeting the following CSS
 - Dropdown button: `roamjs-attribute-select-button`
 - Popover content: `roamjs-attribute-select-popover`
 
+## Developer API
+
+For developers of other extensions who want to interact with the Attribute Select feature, we expose the following API, available on the global `window.roamjs.extension.workbench` object:
+
+- `refreshAttributeSelect` - `() => void` Refreshes the defined attributes and updates the attribute observer. This is useful when attributes or options have been programmatically updated and need to be reflected in the UI without a page reload.
+
 <!-- # Demo -->
 
 <!-- TODO -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "workbench",
-  "version": "1.5.5",
+  "version": "1.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "workbench",
-      "version": "1.5.5",
+      "version": "1.6.0",
       "dependencies": {
         "@mozilla/readability": "^0.3.0",
         "buffer": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@types/mozilla-readability": "^0.2.0",
     "@types/turndown": "^5.0.1"
   },
-  "version": "1.5.5",
+  "version": "1.6.0",
   "samepage": {
     "extends": "node_modules/roamjs-components/package.json"
   }

--- a/src/features/attributeSelect.tsx
+++ b/src/features/attributeSelect.tsx
@@ -775,3 +775,11 @@ export const toggleFeature = async (flag: boolean) => {
     unloads.clear();
   }
 };
+
+// @ts-ignore
+window.roamjs.extension.workbench = {
+  refreshAttributeSelect: () => {
+    definedAttributes = getDefinedAttributes();
+    updateAttributeObserver();
+  },
+};

--- a/src/features/attributeSelect.tsx
+++ b/src/features/attributeSelect.tsx
@@ -766,6 +766,13 @@ export const toggleFeature = async (flag: boolean) => {
 
     updateAttributeObserver();
 
+    window.roamjs.extension.workbench = {
+      refreshAttributeSelect: () => {
+        definedAttributes = getDefinedAttributes();
+        updateAttributeObserver();
+      },
+    };
+
     unloads.add(() => {
       observer.disconnect();
       attributeObserver.disconnect();
@@ -773,13 +780,8 @@ export const toggleFeature = async (flag: boolean) => {
   } else {
     unloads.forEach((u) => u());
     unloads.clear();
+    if (window.roamjs?.extension?.workbench?.refreshAttributeSelect) {
+      delete window.roamjs.extension.workbench.refreshAttributeSelect;
+    }
   }
-};
-
-// @ts-ignore
-window.roamjs.extension.workbench = {
-  refreshAttributeSelect: () => {
-    definedAttributes = getDefinedAttributes();
-    updateAttributeObserver();
-  },
 };


### PR DESCRIPTION
This PR adds ability to refresh defined attributes and update the observer.

A dev requested the ability to programmatically add attributes and attribute options via their plugin.  As options are currently just an embed block rather than custom ui/functions and the settings are just stored as child blocks, I've decided to just expose an ability to refresh attributes/observer instead of creating/rewriting multiple functions.

This should suffice until Attribute Select becomes more mature and a more granular API is warranted.