### PR TITLE
Move inline styles to a style script (Closes #484)

### DIFF
--- a/src/components/SettingsTable.tsx
+++ b/src/components/SettingsTable.tsx
@@ -34,12 +34,10 @@ const SettingsTable =
       overflow: "hidden",
       textOverflow: "ellipsis",
       whiteSpace: "nowrap",
-      color: "white",
       verticalAlign: "middle",
     };
     const featureStyle: React.CSSProperties = {
       textAlign: "left",
-      color: "white",
       verticalAlign: "middle",
     };
     const thBorder: React.CSSProperties = {
@@ -55,6 +53,14 @@ const SettingsTable =
 
     return (
       <>
+        <style>
+          {/* override blueprint styles while still allowing 3rd party theming */}
+          {`
+            .rm-extensions-settings table.bp3-html-table th {
+              color: white;
+            }
+          `}
+        </style>
         <HTMLTable
           bordered={false}
           style={{ ...noBorder }}


### PR DESCRIPTION
So that 3rd party theming is still available.

User reported [here](https://github.com/RoamJS/workbench/issues/484).

https://www.loom.com/share/8c6da0de1016486d9d19601c90e53cb9