### PR TITLE
Another settings table css fix

### DIFF
--- a/src/components/SettingsTable.tsx
+++ b/src/components/SettingsTable.tsx
@@ -56,8 +56,8 @@ const SettingsTable =
         <style>
           {/* override blueprint styles while still allowing 3rd party theming */}
           {`
-            .rm-extensions-settings table.bp3-html-table th,
-            .rm-extensions-settings table.bp3-html-table td {
+            .rm-settings-panel table.workbench-settings th,
+            .rm-settings-panel table.workbench-settings td {
               color: white;
             }
           `}


### PR DESCRIPTION
The view works fine
![image](https://github.com/user-attachments/assets/274ae51d-7ee0-4261-9ff5-d18ce1b5e5f2)

But this view doesn't include `.rm-extensions-settings`
![image](https://github.com/user-attachments/assets/b4f704e2-edd6-4ed6-af23-69a53145bdc3)

Changed `.rm-extensions-settings` to `.rm-settings-panel`.
Also changed `.bp3-html-table` to `.workbench-settings` to ensure we are only targeting our table 
(currently, the component unmounts when tab changes, so wasn't an issue, but this should ensure it)

https://www.loom.com/share/da498abc63464494808cd4db118a9784