### PR TITLE
[codex] Add SmartBlocks weekly note templates

### DIFF
--- a/docs/weekly-notes.md
+++ b/docs/weekly-notes.md
@@ -24,6 +24,14 @@ would create a page name of:
 
 For format, check out [this page](https://date-fns.org/v2.21.1/docs/format) for the syntax on what each symbol means.
 
+# Template
+
+You can add blocks under the `Template` setting on the `roam/js/weekly-notes` page. These blocks will be inserted when a new weekly note page is created.
+
+If the template includes SmartBlocks syntax like `<%DATE:In one week%>`, WorkBench will run the template through SmartBlocks when SmartBlocks is enabled. Relative dates are based on the start date parsed from the weekly page title, so `<%DATE:In one week%>` resolves to one week after that weekly note's start date.
+
+If SmartBlocks is not enabled, WorkBench will show a warning and copy the template blocks without processing the SmartBlocks commands.
+
 # Auto Tagging
 
 When a new weekly page is created, the weekly page will be tagged in all of the daily pages that are part of the week. The tag will be added as the top block on the page. This could be toggled on and off in the `roam/js/weekly-notes` page.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "workbench",
-  "version": "1.7.4",
+  "version": "1.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "workbench",
-      "version": "1.7.4",
+      "version": "1.8.0",
       "dependencies": {
         "@mozilla/readability": "^0.3.0",
         "buffer": "^6.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "color": "^4.2.3",
         "markmap-lib": "^0.11.1",
         "markmap-view": "^0.2.1",
-        "roamjs-components": "^0.88.3",
+        "roamjs-components": "^0.88.4",
         "tesseract.js": "^2.1.4",
         "turndown": "^7.1.1"
       },
@@ -13411,9 +13411,9 @@
       }
     },
     "node_modules/roamjs-components": {
-      "version": "0.88.3",
-      "resolved": "https://registry.npmjs.org/roamjs-components/-/roamjs-components-0.88.3.tgz",
-      "integrity": "sha512-eCKpgKSLoxtOqRZG9c0KOwTQIu2WrYzuipvfeGI377dzUZ8AIj4hJaq6qYzBPL7N1bnns0mMcjHiBhOgLgQTBg==",
+      "version": "0.88.4",
+      "resolved": "https://registry.npmjs.org/roamjs-components/-/roamjs-components-0.88.4.tgz",
+      "integrity": "sha512-yMaIvZt6OTLhl87IEKF/IQcIRgeaT56nauYVtgDsjBs85wWUmskx8W++VEjdJaH1QN8pDEz7UOVI1aRCZQw1Rw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -25006,9 +25006,9 @@
       }
     },
     "roamjs-components": {
-      "version": "0.88.3",
-      "resolved": "https://registry.npmjs.org/roamjs-components/-/roamjs-components-0.88.3.tgz",
-      "integrity": "sha512-eCKpgKSLoxtOqRZG9c0KOwTQIu2WrYzuipvfeGI377dzUZ8AIj4hJaq6qYzBPL7N1bnns0mMcjHiBhOgLgQTBg==",
+      "version": "0.88.4",
+      "resolved": "https://registry.npmjs.org/roamjs-components/-/roamjs-components-0.88.4.tgz",
+      "integrity": "sha512-yMaIvZt6OTLhl87IEKF/IQcIRgeaT56nauYVtgDsjBs85wWUmskx8W++VEjdJaH1QN8pDEz7UOVI1aRCZQw1Rw==",
       "requires": {
         "@samepage/scripts": "^0.74.2",
         "color": "^4.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "color": "^4.2.3",
         "markmap-lib": "^0.11.1",
         "markmap-view": "^0.2.1",
-        "roamjs-components": "^0.85.0",
+        "roamjs-components": "^0.88.3",
         "tesseract.js": "^2.1.4",
         "turndown": "^7.1.1"
       },
@@ -3552,51 +3552,12 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/aws-sdk": {
-      "version": "2.1369.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1369.0.tgz",
-      "integrity": "sha512-DdCQjlhQDi9w8J4moqECrrp9ARWCay0UI38adPSS0GG43gh3bl3OoMlgKJ8aZxi4jUvzE48K9yhFHz4y/mazZw==",
-      "dependencies": {
-        "buffer": "4.9.2",
-        "events": "1.1.1",
-        "ieee754": "1.1.13",
-        "jmespath": "0.16.0",
-        "querystring": "0.2.0",
-        "sax": "1.2.1",
-        "url": "0.10.3",
-        "util": "^0.12.4",
-        "uuid": "8.0.0",
-        "xml2js": "0.5.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/aws-sdk-plus": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/aws-sdk-plus/-/aws-sdk-plus-0.5.3.tgz",
-      "integrity": "sha512-C/I1sWXAA5gRh5G4XbqnnVTGfzKimXJVkgBl62rt4SUAjOyakMICvSG/MaS4xzS+6umiVgKH8liWsNmiSueXXA==",
-      "dependencies": {
-        "aws-sdk": "^2.1004.0",
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2"
-      }
-    },
-    "node_modules/aws-sdk/node_modules/buffer": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-      "dependencies": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
       }
     },
     "node_modules/axios": {
@@ -3809,6 +3770,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "peer": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -4898,14 +4860,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/events": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==",
-      "engines": {
-        "node": ">=0.4.x"
-      }
-    },
     "node_modules/fast-glob": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
@@ -5040,6 +4994,7 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "peer": true,
       "dependencies": {
         "is-callable": "^1.1.3"
       }
@@ -5114,7 +5069,8 @@
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "peer": true
     },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
@@ -5146,6 +5102,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
       "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+      "peer": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -5191,6 +5148,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
       "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "peer": true,
       "dependencies": {
         "get-intrinsic": "^1.1.3"
       },
@@ -5214,6 +5172,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "peer": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -5255,6 +5214,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
       "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -5266,6 +5226,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -5277,6 +5238,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
       "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "peer": true,
       "dependencies": {
         "has-symbols": "^1.0.2"
       },
@@ -5437,7 +5399,8 @@
     "node_modules/ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+      "peer": true
     },
     "node_modules/immediate": {
       "version": "3.0.6",
@@ -11624,6 +11587,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
       "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -11698,6 +11662,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
       "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -11789,20 +11754,6 @@
       "peer": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-generator-function": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
-      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
-      "dependencies": {
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-glob": {
@@ -11936,6 +11887,7 @@
       "version": "1.1.10",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
       "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "peer": true,
       "dependencies": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
@@ -11992,7 +11944,8 @@
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "peer": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -12045,14 +11998,6 @@
         "jiti": "bin/jiti.js"
       }
     },
-    "node_modules/jmespath": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
-      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/jpeg-autorotate": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/jpeg-autorotate/-/jpeg-autorotate-7.1.1.tgz",
@@ -12079,7 +12024,8 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "peer": true
     },
     "node_modules/jsdom": {
       "version": "20.0.3",
@@ -12295,6 +12241,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "peer": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -12543,6 +12490,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13160,15 +13108,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
-      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
-      "engines": {
-        "node": ">=0.4.x"
-      }
-    },
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -13199,6 +13138,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -13223,6 +13163,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
       "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -13470,13 +13411,13 @@
       }
     },
     "node_modules/roamjs-components": {
-      "version": "0.85.0",
-      "resolved": "https://registry.npmjs.org/roamjs-components/-/roamjs-components-0.85.0.tgz",
-      "integrity": "sha512-IdAWXhZCW3GjiiQQehkQT/5QnJYFssH2G/HcFn8QqjKhrE+zvX23lOPNhx/yGQxtomPtRmB+q4AbVGfqNaAOXQ==",
+      "version": "0.88.3",
+      "resolved": "https://registry.npmjs.org/roamjs-components/-/roamjs-components-0.88.3.tgz",
+      "integrity": "sha512-eCKpgKSLoxtOqRZG9c0KOwTQIu2WrYzuipvfeGI377dzUZ8AIj4hJaq6qYzBPL7N1bnns0mMcjHiBhOgLgQTBg==",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@samepage/scripts": "^0.74.2",
-        "aws-sdk-plus": "^0.5.3",
         "color": "^4.0.1",
         "date-fns": "^2.27.0",
         "edn-data": "^1.0.0",
@@ -13553,17 +13494,13 @@
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "peer": true
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
-    "node_modules/sax": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA=="
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -13581,6 +13518,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
       "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -14134,15 +14072,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/url": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-      "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
-      "dependencies": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      }
-    },
     "node_modules/url-parse": {
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
@@ -14153,11 +14082,6 @@
         "requires-port": "^1.0.0"
       }
     },
-    "node_modules/url/node_modules/punycode": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw=="
-    },
     "node_modules/use-sync-external-store": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
@@ -14167,32 +14091,11 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
-    "node_modules/util": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-      "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "is-arguments": "^1.0.4",
-        "is-generator-function": "^1.0.7",
-        "is-typed-array": "^1.1.3",
-        "safe-buffer": "^5.1.2",
-        "which-typed-array": "^1.1.2"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "peer": true
-    },
-    "node_modules/uuid": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
-      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
@@ -14320,6 +14223,7 @@
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
       "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+      "peer": true,
       "dependencies": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
@@ -14385,26 +14289,6 @@
       "peer": true,
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/xml2js": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
-      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
-      "dependencies": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "engines": {
-        "node": ">=4.0"
       }
     },
     "node_modules/xmlchars": {
@@ -17661,46 +17545,8 @@
     "available-typed-arrays": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
-      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
-    },
-    "aws-sdk": {
-      "version": "2.1369.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1369.0.tgz",
-      "integrity": "sha512-DdCQjlhQDi9w8J4moqECrrp9ARWCay0UI38adPSS0GG43gh3bl3OoMlgKJ8aZxi4jUvzE48K9yhFHz4y/mazZw==",
-      "requires": {
-        "buffer": "4.9.2",
-        "events": "1.1.1",
-        "ieee754": "1.1.13",
-        "jmespath": "0.16.0",
-        "querystring": "0.2.0",
-        "sax": "1.2.1",
-        "url": "0.10.3",
-        "util": "^0.12.4",
-        "uuid": "8.0.0",
-        "xml2js": "0.5.0"
-      },
-      "dependencies": {
-        "buffer": {
-          "version": "4.9.2",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-          "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-          "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4",
-            "isarray": "^1.0.0"
-          }
-        }
-      }
-    },
-    "aws-sdk-plus": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/aws-sdk-plus/-/aws-sdk-plus-0.5.3.tgz",
-      "integrity": "sha512-C/I1sWXAA5gRh5G4XbqnnVTGfzKimXJVkgBl62rt4SUAjOyakMICvSG/MaS4xzS+6umiVgKH8liWsNmiSueXXA==",
-      "requires": {
-        "aws-sdk": "^2.1004.0",
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2"
-      }
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "peer": true
     },
     "axios": {
       "version": "0.27.2",
@@ -17842,6 +17688,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "peer": true,
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -18728,11 +18575,6 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "peer": true
     },
-    "events": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw=="
-    },
     "fast-glob": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
@@ -18824,6 +18666,7 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "peer": true,
       "requires": {
         "is-callable": "^1.1.3"
       }
@@ -18882,7 +18725,8 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "peer": true
     },
     "functions-have-names": {
       "version": "1.2.3",
@@ -18905,6 +18749,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
       "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+      "peer": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -18938,6 +18783,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
       "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "peer": true,
       "requires": {
         "get-intrinsic": "^1.1.3"
       }
@@ -18958,6 +18804,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "peer": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -18986,17 +18833,20 @@
     "has-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg=="
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "peer": true
     },
     "has-symbols": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "peer": true
     },
     "has-tostringtag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
       "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "peer": true,
       "requires": {
         "has-symbols": "^1.0.2"
       }
@@ -19115,7 +18965,8 @@
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+      "peer": true
     },
     "immediate": {
       "version": "3.0.6",
@@ -23838,6 +23689,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
       "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "peer": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -23890,7 +23742,8 @@
     "is-callable": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w=="
+      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+      "peer": true
     },
     "is-ci": {
       "version": "2.0.0",
@@ -23946,14 +23799,6 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "peer": true
-    },
-    "is-generator-function": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
-      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
-      "requires": {
-        "has-tostringtag": "^1.0.0"
-      }
     },
     "is-glob": {
       "version": "4.0.3",
@@ -24043,6 +23888,7 @@
       "version": "1.1.10",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
       "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "peer": true,
       "requires": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
@@ -24084,7 +23930,8 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "peer": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -24125,11 +23972,6 @@
       "integrity": "sha512-oVhqoRDaBXf7sjkll95LHVS6Myyyb1zaunVwk4Z0+WPSW4gjS0pl01zYKHScTuyEhQsFxV5L4DR5r+YqSyqyyg==",
       "peer": true
     },
-    "jmespath": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
-      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw=="
-    },
     "jpeg-autorotate": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/jpeg-autorotate/-/jpeg-autorotate-7.1.1.tgz",
@@ -24150,7 +23992,8 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "peer": true
     },
     "jsdom": {
       "version": "20.0.3",
@@ -24331,6 +24174,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "peer": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -24516,7 +24360,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "peer": true
     },
     "object-hash": {
       "version": "3.0.0",
@@ -24928,11 +24773,6 @@
       "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
       "peer": true
     },
-    "querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g=="
-    },
     "querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -24949,6 +24789,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -24967,6 +24808,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
       "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -25164,12 +25006,11 @@
       }
     },
     "roamjs-components": {
-      "version": "0.85.0",
-      "resolved": "https://registry.npmjs.org/roamjs-components/-/roamjs-components-0.85.0.tgz",
-      "integrity": "sha512-IdAWXhZCW3GjiiQQehkQT/5QnJYFssH2G/HcFn8QqjKhrE+zvX23lOPNhx/yGQxtomPtRmB+q4AbVGfqNaAOXQ==",
+      "version": "0.88.3",
+      "resolved": "https://registry.npmjs.org/roamjs-components/-/roamjs-components-0.88.3.tgz",
+      "integrity": "sha512-eCKpgKSLoxtOqRZG9c0KOwTQIu2WrYzuipvfeGI377dzUZ8AIj4hJaq6qYzBPL7N1bnns0mMcjHiBhOgLgQTBg==",
       "requires": {
         "@samepage/scripts": "^0.74.2",
-        "aws-sdk-plus": "^0.5.3",
         "color": "^4.0.1",
         "date-fns": "^2.27.0",
         "edn-data": "^1.0.0",
@@ -25196,17 +25037,13 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "peer": true
     },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
-    "sax": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA=="
     },
     "saxes": {
       "version": "6.0.0",
@@ -25221,6 +25058,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
       "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -25648,22 +25486,6 @@
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
       "peer": true
     },
-    "url": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-      "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
-      "requires": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw=="
-        }
-      }
-    },
     "url-parse": {
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
@@ -25681,29 +25503,11 @@
       "peer": true,
       "requires": {}
     },
-    "util": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-      "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
-      "requires": {
-        "inherits": "^2.0.3",
-        "is-arguments": "^1.0.4",
-        "is-generator-function": "^1.0.7",
-        "is-typed-array": "^1.1.3",
-        "safe-buffer": "^5.1.2",
-        "which-typed-array": "^1.1.2"
-      }
-    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "peer": true
-    },
-    "uuid": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
-      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw=="
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",
@@ -25807,6 +25611,7 @@
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
       "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+      "peer": true,
       "requires": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
@@ -25844,20 +25649,6 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
       "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
       "peer": true
-    },
-    "xml2js": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
-      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
-      "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      }
-    },
-    "xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
     "xmlchars": {
       "version": "2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "workbench",
-  "version": "1.8.1",
+  "version": "1.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "workbench",
-      "version": "1.8.1",
+      "version": "1.8.0",
       "dependencies": {
         "@mozilla/readability": "^0.3.0",
         "buffer": "^6.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "workbench",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "workbench",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "dependencies": {
         "@mozilla/readability": "^0.3.0",
         "buffer": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "color": "^4.2.3",
     "markmap-lib": "^0.11.1",
     "markmap-view": "^0.2.1",
-    "roamjs-components": "^0.88.3",
+    "roamjs-components": "^0.88.4",
     "tesseract.js": "^2.1.4",
     "turndown": "^7.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@types/mozilla-readability": "^0.2.0",
     "@types/turndown": "^5.0.1"
   },
-  "version": "1.8.0",
+  "version": "1.8.1",
   "samepage": {
     "extends": "node_modules/roamjs-components/package.json"
   }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@types/mozilla-readability": "^0.2.0",
     "@types/turndown": "^5.0.1"
   },
-  "version": "1.8.1",
+  "version": "1.8.0",
   "samepage": {
     "extends": "node_modules/roamjs-components/package.json"
   }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "color": "^4.2.3",
     "markmap-lib": "^0.11.1",
     "markmap-view": "^0.2.1",
-    "roamjs-components": "^0.85.0",
+    "roamjs-components": "^0.88.3",
     "tesseract.js": "^2.1.4",
     "turndown": "^7.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@types/mozilla-readability": "^0.2.0",
     "@types/turndown": "^5.0.1"
   },
-  "version": "1.7.4",
+  "version": "1.8.0",
   "samepage": {
     "extends": "node_modules/roamjs-components/package.json"
   }

--- a/src/features/weekly-notes.ts
+++ b/src/features/weekly-notes.ts
@@ -92,6 +92,43 @@ const hasNodeContent = (node: InputTextNode | RoamBasicNode): boolean =>
 const hasSmartBlockSyntax = (node: RoamBasicNode): boolean =>
   node.text.includes("<%") || node.children.some(hasSmartBlockSyntax);
 
+type InstalledExtension = {
+  id?: string;
+  name?: string;
+  enabled?: boolean;
+  version?: string;
+};
+
+const isSmartBlocksEnabled = () => {
+  const getInstalledExtensions = (
+    window.roamAlphaAPI as typeof window.roamAlphaAPI & {
+      extension?: {
+        getInstalledExtensions?: () => Record<string, InstalledExtension>;
+      };
+    }
+  ).extension?.getInstalledExtensions;
+  if (!getInstalledExtensions) return true;
+
+  try {
+    const installedExtensions = getInstalledExtensions();
+    const smartblocks = Object.entries(installedExtensions).find(
+      ([key, extension]) => {
+        const id = (extension.id || key).toLowerCase();
+        const name = (extension.name || "").toLowerCase();
+        return (
+          id === "smartblocks" ||
+          id.endsWith("+smartblocks") ||
+          name === "smartblocks"
+        );
+      }
+    )?.[1];
+    return !!smartblocks && smartblocks.enabled !== false;
+  } catch (e) {
+    console.error(e);
+    return true;
+  }
+};
+
 const waitForSmartBlocks = () =>
   new Promise<typeof window.roamjs.extension.smartblocks | undefined>(
     (resolve) => {
@@ -99,6 +136,10 @@ const waitForSmartBlocks = () =>
       const smartblocks = getSmartBlocks();
       if (smartblocks) {
         resolve(smartblocks);
+        return;
+      }
+      if (!isSmartBlocksEnabled()) {
+        resolve(undefined);
         return;
       }
 
@@ -112,7 +153,7 @@ const waitForSmartBlocks = () =>
       const timeout = window.setTimeout(() => {
         cleanup();
         resolve(getSmartBlocks());
-      }, 5000);
+      }, 1500);
       const handleSmartBlocksLoaded = () => {
         cleanup();
         resolve(getSmartBlocks());

--- a/src/features/weekly-notes.ts
+++ b/src/features/weekly-notes.ts
@@ -6,15 +6,24 @@ import subWeeks from "date-fns/subWeeks";
 import { createConfigObserver } from "roamjs-components/components/ConfigPage";
 import TextPanel from "roamjs-components/components/ConfigPanels/TextPanel";
 import FlagPanel from "roamjs-components/components/ConfigPanels/FlagPanel";
+import BlocksPanel from "roamjs-components/components/ConfigPanels/BlocksPanel";
 import getSettingValueFromTree from "roamjs-components/util/getSettingValueFromTree";
 import { render as renderToast } from "roamjs-components/components/Toast";
-import type { OnloadArgs, TreeNode } from "roamjs-components/types/native";
+import type {
+  InputTextNode,
+  OnloadArgs,
+  RoamBasicNode,
+  TreeNode,
+} from "roamjs-components/types/native";
 import createHTMLObserver from "roamjs-components/dom/createHTMLObserver";
 import getPageTitleValueByHtmlElement from "roamjs-components/dom/getPageTitleValueByHtmlElement";
 import getFullTreeByParentUid from "roamjs-components/queries/getFullTreeByParentUid";
+import getChildrenLengthByParentUid from "roamjs-components/queries/getChildrenLengthByParentUid";
 import getPageTitleByPageUid from "roamjs-components/queries/getPageTitleByPageUid";
 import getPageUidByPageTitle from "roamjs-components/queries/getPageUidByPageTitle";
 import toFlexRegex from "roamjs-components/util/toFlexRegex";
+import getSubTree from "roamjs-components/util/getSubTree";
+import stripUid from "roamjs-components/util/stripUid";
 import createBlock from "roamjs-components/writes/createBlock";
 import createPage from "roamjs-components/writes/createPage";
 import { addCommand } from "./workBench";
@@ -77,6 +86,69 @@ const parse = (...args: Parameters<typeof _parse>) => {
   }
 };
 
+const hasNodeContent = (node: InputTextNode | RoamBasicNode): boolean =>
+  !!node.text.trim() || !!node.children?.some(hasNodeContent);
+
+const hasSmartBlockSyntax = (node: RoamBasicNode): boolean =>
+  node.text.includes("<%") || node.children.some(hasSmartBlockSyntax);
+
+const createBlocksFromTemplate = async ({
+  templateNode,
+  pageUid,
+}: {
+  templateNode: RoamBasicNode;
+  pageUid: string;
+}) => {
+  const startingOrder = getChildrenLengthByParentUid(pageUid);
+  await Promise.all(
+    stripUid(templateNode.children)
+      .filter(hasNodeContent)
+      .map((node, order) =>
+        createBlock({
+          node,
+          order: startingOrder + order,
+          parentUid: pageUid,
+        })
+      )
+  );
+};
+
+const renderWeeklyTemplate = async ({
+  tree,
+  pageUid,
+  date,
+}: {
+  tree: RoamBasicNode[];
+  pageUid: string;
+  date?: Date;
+}) => {
+  const templateNode = getSubTree({
+    tree,
+    key: "template",
+  });
+  const templateChildren = templateNode.children.filter(hasNodeContent);
+  if (!templateNode.uid || !templateChildren.length) return;
+
+  const useSmartBlocks = templateChildren.some(hasSmartBlockSyntax);
+  if (useSmartBlocks && !window.roamjs?.extension?.smartblocks) {
+    renderToast({
+      content:
+        "This weekly note template requires SmartBlocks. Enable SmartBlocks in Roam Depot to use this template.",
+      id: "weekly-notes-smartblocks-extension-disabled",
+      intent: "warning",
+    });
+    await createBlocksFromTemplate({ templateNode, pageUid });
+  } else if (useSmartBlocks && window.roamjs?.extension?.smartblocks) {
+    await window.roamjs.extension.smartblocks.triggerSmartblock({
+      srcUid: templateNode.uid,
+      targetUid: pageUid,
+      variables: date ? { DATEBASISMETHOD: date.toJSON() } : undefined,
+    });
+  } else {
+    await createBlocksFromTemplate({ templateNode, pageUid });
+  }
+};
+
 const createWeeklyPage = (pageName: string) => {
   const weekUid = createPage({ title: pageName });
   const tree = getFullTreeByParentUid(getPageUidByPageTitle(CONFIG)).children;
@@ -90,35 +162,58 @@ const createWeeklyPage = (pageName: string) => {
         .replace(/\]/g, "\\]")}$`
     )
   )?.[1];
-  if (!firstDateFormatted) {
-    return weekUid;
-  }
-  const date = parse(firstDateFormatted, dayFormat, new Date());
-  if (!date) {
-    return weekUid;
-  }
-  const weekStartsOn = DAYS.indexOf(day) as 0 | 1 | 2 | 3 | 4 | 5 | 6;
-  const autoTag = tree.some((t) => toFlexRegex("auto tag").test(t.text));
-  const autoEmbed = tree.some((t) => toFlexRegex("auto embed").test(t.text));
-  DAYS.forEach((_, i) => {
-    const dayDate = setDay(date, i, { weekStartsOn });
-    const title = window.roamAlphaAPI.util.dateToPageTitle(dayDate);
-    if (autoTag) {
-      Promise.resolve(
-        getPageUidByPageTitle(title) || createPage({ title })
-      ).then((parentUid) =>
-        createBlock({ node: { text: `#[[${pageName}]]` }, parentUid })
-      );
+
+  weekUid.then(async (pageUid) => {
+    const date = firstDateFormatted
+      ? parse(firstDateFormatted, dayFormat, new Date())
+      : null;
+
+    try {
+      if (date) {
+        const weekStartsOn = DAYS.indexOf(day) as 0 | 1 | 2 | 3 | 4 | 5 | 6;
+        const autoTag = tree.some((t) => toFlexRegex("auto tag").test(t.text));
+        const autoEmbed = tree.some((t) =>
+          toFlexRegex("auto embed").test(t.text)
+        );
+        const tagPromises: Promise<unknown>[] = [];
+        const embedPromises: Promise<unknown>[] = [];
+        DAYS.forEach((_, i) => {
+          const dayDate = setDay(date, i, { weekStartsOn });
+          const title = window.roamAlphaAPI.util.dateToPageTitle(dayDate);
+          if (autoTag) {
+            tagPromises.push(
+              Promise.resolve(
+                getPageUidByPageTitle(title) || createPage({ title })
+              ).then((parentUid) =>
+                createBlock({ node: { text: `#[[${pageName}]]` }, parentUid })
+              )
+            );
+          }
+          if (autoEmbed) {
+            embedPromises.push(
+              createBlock({
+                node: { text: `{{[[embed]]:[[${title}]]}}` },
+                parentUid: pageUid,
+                order: (i - weekStartsOn + 7) % 7,
+              })
+            );
+          }
+        });
+        await Promise.all(embedPromises);
+        await renderWeeklyTemplate({ tree, pageUid, date });
+        await Promise.all(tagPromises);
+      } else {
+        await renderWeeklyTemplate({ tree, pageUid });
+      }
+    } catch (e) {
+      console.error(e);
+      renderToast({
+        id: "weekly-notes-template-error",
+        content: `Weekly note template failed: ${(e as Error).message}`,
+        intent: "danger",
+      });
     }
-    if (autoEmbed) {
-      weekUid.then((parentUid) =>
-        createBlock({
-          node: { text: `{{[[embed]]:[[${title}]]}}` },
-          parentUid,
-          order: (i - weekStartsOn + 7) % 7,
-        })
-      );
-    }
+    return pageUid;
   });
   return weekUid;
 };
@@ -175,6 +270,13 @@ export const toggleFeature = (
                 Panel: FlagPanel,
                 description:
                   "Automatically embed the related daily pages into a newly created weekly page",
+              } as Field<UnionField>,
+              {
+                title: "Template",
+                Panel: BlocksPanel,
+                defaultValue: [],
+                description:
+                  "Blocks to insert into newly created weekly note pages. Supports SmartBlocks syntax when SmartBlocks is enabled.",
               } as Field<UnionField>,
             ],
           },

--- a/src/features/weekly-notes.ts
+++ b/src/features/weekly-notes.ts
@@ -92,21 +92,9 @@ const hasNodeContent = (node: InputTextNode | RoamBasicNode): boolean =>
 const hasSmartBlockSyntax = (node: RoamBasicNode): boolean =>
   node.text.includes("<%") || node.children.some(hasSmartBlockSyntax);
 
-type InstalledExtension = {
-  id?: string;
-  name?: string;
-  enabled?: boolean;
-  version?: string;
-};
-
 const isSmartBlocksEnabled = () => {
-  const getInstalledExtensions = (
-    window.roamAlphaAPI as typeof window.roamAlphaAPI & {
-      depot?: {
-        getInstalledExtensions?: () => Record<string, InstalledExtension>;
-      };
-    }
-  ).depot?.getInstalledExtensions;
+  const getInstalledExtensions =
+    window.roamAlphaAPI.depot?.getInstalledExtensions;
   if (!getInstalledExtensions) return true;
 
   try {

--- a/src/features/weekly-notes.ts
+++ b/src/features/weekly-notes.ts
@@ -92,6 +92,47 @@ const hasNodeContent = (node: InputTextNode | RoamBasicNode): boolean =>
 const hasSmartBlockSyntax = (node: RoamBasicNode): boolean =>
   node.text.includes("<%") || node.children.some(hasSmartBlockSyntax);
 
+const waitForSmartBlocks = () =>
+  new Promise<typeof window.roamjs.extension.smartblocks | undefined>(
+    (resolve) => {
+      const getSmartBlocks = () => window.roamjs?.extension?.smartblocks;
+      const smartblocks = getSmartBlocks();
+      if (smartblocks) {
+        resolve(smartblocks);
+        return;
+      }
+
+      const interval = window.setInterval(() => {
+        const smartblocks = getSmartBlocks();
+        if (smartblocks) {
+          cleanup();
+          resolve(smartblocks);
+        }
+      }, 250);
+      const timeout = window.setTimeout(() => {
+        cleanup();
+        resolve(getSmartBlocks());
+      }, 5000);
+      const handleSmartBlocksLoaded = () => {
+        cleanup();
+        resolve(getSmartBlocks());
+      };
+      const cleanup = () => {
+        window.clearInterval(interval);
+        window.clearTimeout(timeout);
+        document.body.removeEventListener(
+          "roamjs:smartblocks:loaded",
+          handleSmartBlocksLoaded
+        );
+      };
+
+      document.body.addEventListener(
+        "roamjs:smartblocks:loaded",
+        handleSmartBlocksLoaded
+      );
+    }
+  );
+
 const createBlocksFromTemplate = async ({
   templateNode,
   pageUid,
@@ -130,7 +171,8 @@ const renderWeeklyTemplate = async ({
   if (!templateNode.uid || !templateChildren.length) return;
 
   const useSmartBlocks = templateChildren.some(hasSmartBlockSyntax);
-  if (useSmartBlocks && !window.roamjs?.extension?.smartblocks) {
+  const smartblocks = useSmartBlocks ? await waitForSmartBlocks() : undefined;
+  if (useSmartBlocks && !smartblocks) {
     renderToast({
       content:
         "This weekly note template requires SmartBlocks. Enable SmartBlocks in Roam Depot to use this template.",
@@ -138,8 +180,8 @@ const renderWeeklyTemplate = async ({
       intent: "warning",
     });
     await createBlocksFromTemplate({ templateNode, pageUid });
-  } else if (useSmartBlocks && window.roamjs?.extension?.smartblocks) {
-    await window.roamjs.extension.smartblocks.triggerSmartblock({
+  } else if (smartblocks) {
+    await smartblocks.triggerSmartblock({
       srcUid: templateNode.uid,
       targetUid: pageUid,
       variables: date ? { DATEBASISMETHOD: date.toJSON() } : undefined,

--- a/src/features/weekly-notes.ts
+++ b/src/features/weekly-notes.ts
@@ -102,11 +102,11 @@ type InstalledExtension = {
 const isSmartBlocksEnabled = () => {
   const getInstalledExtensions = (
     window.roamAlphaAPI as typeof window.roamAlphaAPI & {
-      extension?: {
+      depot?: {
         getInstalledExtensions?: () => Record<string, InstalledExtension>;
       };
     }
-  ).extension?.getInstalledExtensions;
+  ).depot?.getInstalledExtensions;
   if (!getInstalledExtensions) return true;
 
   try {


### PR DESCRIPTION
## Summary
- Add a Weekly Notes `Template` config block for new weekly page content.
- Render weekly templates through SmartBlocks when `<%...%>` syntax is present, with relative dates anchored to the parsed week start.
- Document the new template behavior and bump WorkBench to `1.8.0`.

## Validation
- `npm run build:roam` passes with `src built with 0 errors`.
- `npx tsc --noEmit -p tsconfig.json` was attempted and is blocked by existing unrelated strict-null errors in `jumpNav`, `livePreview`, `mindmap`, `privacyMode`, and `tagCycle`.